### PR TITLE
Added description to add device_id on firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ The Robinhood API is not publicly available but has been [explored extensively](
 var robinhoodUsername = 'janedoe';
 var robinhoodPassword = 'passw0rd';
 ```
-6. (As of 1/19/20) Log into Robinhood on the Web to [https://stackoverflow.com/questions/55902967/is-there-any-way-to-get-a-bearer-token-now-since-robinhood-has-changed-the-api/56841942](obtain a device_id) and add it to your payload to get past RH's Oauth flow.
-6. Select the menu item **File > Save**. Give the script project a name and click OK.
-7. Refresh the spreadsheet. You will now be able to use custom functions to retrieve your Robinhood data!
+6. (As of 1/19/20) Log into Robinhood on the Web to [obtain a device_id](https://stackoverflow.com/questions/55902967/is-there-any-way-to-get-a-bearer-token-now-since-robinhood-has-changed-the-api/56841942) and add it to your payload to get past RH's Oauth flow.
+    1. For firefox user, open the Storage Inspector by pressing its `Shift + F9` keyboard shortcut. Then `Cookie -> https://robinhood.com -> device_id`
+7. Select the menu item **File > Save**. Give the script project a name and click OK.
+8. Refresh the spreadsheet. You will now be able to use custom functions to retrieve your Robinhood data!
 
 ## Custom functions
 


### PR DESCRIPTION
The StackOverflow answer requires users to use javascript. If the user already browsing this page, they probably already using the browser. With the new description, people can find their device_id easier. 